### PR TITLE
static constexpr variables need definitions

### DIFF
--- a/mods_handler.cc
+++ b/mods_handler.cc
@@ -12,6 +12,21 @@ Copyright 2018 Ahmet Inan <xdsopl@gmail.com>
 #include "modulation.hh"
 #include "testbench.hh"
 
+template <typename TYPE, typename CODE>
+constexpr typename TYPE::value_type PhaseShiftKeying<4, TYPE, CODE>::rcp_sqrt_2;
+template <typename TYPE, typename CODE>
+constexpr TYPE PhaseShiftKeying<8, TYPE, CODE>::rot_acw;
+template <typename TYPE, typename CODE>
+constexpr TYPE PhaseShiftKeying<8, TYPE, CODE>::rot_cw;
+template <typename TYPE, typename CODE>
+constexpr typename TYPE::value_type QuadratureAmplitudeModulation<16, TYPE, CODE>::AMP;
+template <typename TYPE, typename CODE>
+constexpr typename TYPE::value_type QuadratureAmplitudeModulation<64, TYPE, CODE>::AMP;
+template <typename TYPE, typename CODE>
+constexpr typename TYPE::value_type QuadratureAmplitudeModulation<256, TYPE, CODE>::AMP;
+template <typename TYPE, typename CODE>
+constexpr typename TYPE::value_type QuadratureAmplitudeModulation<1024, TYPE, CODE>::AMP;
+
 template <int LEN>
 ModulationInterface<complex_type, code_type> *create_modulation(char *name)
 {


### PR DESCRIPTION
When I tried to build this code with the Xilinx SDSoC compiler (sds++), it failed at link time, complaining about missing definitions for some of the static constexpr members that are declared as part of the modulation formats. 
```
/mnt/mythpc-develop/Develop/LDPC/Debug/mods_handler.o: In function `QuadratureAmplitudeModulation<1024, std::complex<float>, signed char>::map(signed char*)':
/mnt/mythpc-develop/Develop/LDPC/qam.hh:249: undefined reference to `QuadratureAmplitudeModulation<1024, std::complex<float>, signed char>::AMP'
/mnt/mythpc-develop/Develop/LDPC/qam.hh:249: undefined reference to `QuadratureAmplitudeModulation<1024, std::complex<float>, signed char>::AMP'
/mnt/mythpc-develop/Develop/LDPC/Debug/mods_handler.o: In function `QuadratureAmplitudeModulation<256, std::complex<float>, signed char>::map(signed char*)':
/mnt/mythpc-develop/Develop/LDPC/qam.hh:183: undefined reference to `QuadratureAmplitudeModulation<256, std::complex<float>, signed char>::AMP'
/mnt/mythpc-develop/Develop/LDPC/qam.hh:183: undefined reference to `QuadratureAmplitudeModulation<256, std::complex<float>, signed char>::AMP'
/mnt/mythpc-develop/Develop/LDPC/Debug/mods_handler.o: In function `QuadratureAmplitudeModulation<64, std::complex<float>, signed char>::map(signed char*)':
/mnt/mythpc-develop/Develop/LDPC/qam.hh:121: undefined reference to `QuadratureAmplitudeModulation<64, std::complex<float>, signed char>::AMP'
make: *** [LDPC.elf] Error 1
/mnt/mythpc-develop/Develop/LDPC/qam.hh:121: undefined reference to `QuadratureAmplitudeModulation<64, std::complex<float>, signed char>::AMP'
/mnt/mythpc-develop/Develop/LDPC/Debug/mods_handler.o: In function `QuadratureAmplitudeModulation<16, std::complex<float>, signed char>::map(signed char*)':
/mnt/mythpc-develop/Develop/LDPC/qam.hh:63: undefined reference to `QuadratureAmplitudeModulation<16, std::complex<float>, signed char>::AMP'
/mnt/mythpc-develop/Develop/LDPC/qam.hh:63: undefined reference to `QuadratureAmplitudeModulation<16, std::complex<float>, signed char>::AMP'
/mnt/mythpc-develop/Develop/LDPC/Debug/mods_handler.o: In function `PhaseShiftKeying<8, std::complex<float>, signed char>::hard(signed char*, std::complex<float>)':
/mnt/mythpc-develop/Develop/LDPC/psk.hh:124: undefined reference to `PhaseShiftKeying<8, std::complex<float>, signed char>::rot_cw'
/mnt/mythpc-develop/Develop/LDPC/psk.hh:124: undefined reference to `PhaseShiftKeying<8, std::complex<float>, signed char>::rot_cw'
/mnt/mythpc-develop/Develop/LDPC/Debug/mods_handler.o: In function `PhaseShiftKeying<8, std::complex<float>, signed char>::soft(signed char*, std::complex<float>, float)':
/mnt/mythpc-develop/Develop/LDPC/psk.hh:132: undefined reference to `PhaseShiftKeying<8, std::complex<float>, signed char>::rot_cw'
/mnt/mythpc-develop/Develop/LDPC/psk.hh:132: undefined reference to `PhaseShiftKeying<8, std::complex<float>, signed char>::rot_cw'
/mnt/mythpc-develop/Develop/LDPC/Debug/mods_handler.o: In function `PhaseShiftKeying<8, std::complex<float>, signed char>::map(signed char*)':
/mnt/mythpc-develop/Develop/LDPC/psk.hh:144: undefined reference to `PhaseShiftKeying<8, std::complex<float>, signed char>::rot_acw'
/mnt/mythpc-develop/Develop/LDPC/psk.hh:144: undefined reference to `PhaseShiftKeying<8, std::complex<float>, signed char>::rot_acw'
/mnt/mythpc-develop/Develop/LDPC/Debug/mods_handler.o: In function `PhaseShiftKeying<4, std::complex<float>, signed char>::map(signed char*)':
/mnt/mythpc-develop/Develop/LDPC/psk.hh:87: undefined reference to `PhaseShiftKeying<4, std::complex<float>, signed char>::rcp_sqrt_2'
/mnt/mythpc-develop/Develop/LDPC/psk.hh:87: undefined reference to `PhaseShiftKeying<4, std::complex<float>, signed char>::rcp_sqrt_2'
collect2: error: ld returned 1 exit status
ERROR: [SdsCompiler 83-5019] Exiting sds++ : Error when calling 'aarch64-linux-gnu-g++     /mnt/mythpc-develop/Develop/LDPC/Debug/itls_handler.o /mnt/mythpc-develop/Develop/LDPC/Debug/mods_handler.o /mnt/mythpc-develop/Develop/LDPC/Debug/tables_handler.o /mnt/mythpc-develop/Develop/LDPC/Debug/testbench.o /mnt/mythpc-develop/Develop/LDPC/Debug/_sds/swstubs/portinfo.o    -L /opt/Xilinx/SDx/2018.2/target/aarch64-linux/lib -L/mnt/mythpc-develop/Develop/LDPC/Debug/_sds/swstubs -Wl,--start-group  -Wl,--end-group -Wl,--start-group    -lpthread -lsds_lib -lxlnk_stub  -Wl,--end-group -o /mnt/mythpc-develop/Develop/LDPC/Debug/_sds/swstubs/LDPC.elf'
sds++ log file saved as /mnt/mythpc-develop/Develop/LDPC/Debug/_sds/reports/sds.log
ERROR: [SdsCompiler 83-5004] Build failed

makefile:44: recipe for target 'LDPC.elf' failed
```
I think it is right, as those variables are declared, but not defined, this shouldn't really work. I don't know why g++ and clang don't complain, but hey, this is C++ after all...

Anyway, I added some definitions and now the compiler is happy. Thought you may want this for portability.